### PR TITLE
:wrench: fix: Delete redirects to wall rather than posts

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -37,7 +37,7 @@ class PostsController < ApplicationController
   def destroy
     @post = Post.find(params[:id])
     @post.destroy
-    redirect_to posts_path, notice: 'Your post was deleted!'
+    redirect_back(fallback_location: wall_path(session[:wall_user_id]), notice: 'Your post was deleted!')  
   end
 
   def index


### PR DESCRIPTION
Changed delete path to show the wall in use rather than all posts as user couldn't use delete button.